### PR TITLE
fix: empty-list detection fails when sortable root contains anything besides items

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -527,7 +527,7 @@ Sortable.prototype = {
     }
 
     // insert to last
-    if (el !== fromEl && (target === el || !lastChild(el))) {
+    if (el !== fromEl && (target === el || !lastChild(el, options.draggable))) {
       dropEl = lastDropEl = null;
       this._onInsert(event);
       return;


### PR DESCRIPTION
## Bug

When dragging an item into a destination list that is empty of items, the drop silently fails — the item snaps back to its original list, no drop event is emitted on the destination.

This only happens when the destination's sortable root element contains a child element that isn't an item (a wrapper div used for virtualization, a header, a footer, a placeholder, etc.). If the sortable root is the direct parent of items only, there's no bug.

## Cause

_onMove decides "is this destination empty?" with:

if (el !== fromEl && (target === el || !lastChild(el))) {

lastChild(el) is called without a selector, so it returns the last visible child element of any kind. When the destination has zero items but the root still has some other child (a wrapper, a header, etc.), lastChild returns that element. !lastChild(el) becomes false, the "insert into empty list" branch is skipped, and the drop never commits.